### PR TITLE
Hide parcel terminal if country iso code is not 'LT'

### DIFF
--- a/omnivaltshipping.php
+++ b/omnivaltshipping.php
@@ -298,8 +298,10 @@ class OmnivaltShipping extends CarrierModule
 
   /**
    * Check if customer address for parcel terminal carrier is in Lithuania
+   *
    * @param  Object $params
-   * @return Boolean         T
+   *
+   * @return Boolean         True when iso_code is 'LT' or carrier is not 'omnivalt_pt'
    */
   private function canBeDeliveredToParcelTerminal($params) {
     $carrierId = isset($params->id_carrier) ? $params->id_carrier : null;
@@ -320,7 +322,8 @@ class OmnivaltShipping extends CarrierModule
       ';
       $isoCode = Db::getInstance()->getValue($sql);
 
-      if ('LT' !== $isoCode) {
+      $availableIsoCodes = ['LT', 'LV', 'EE'];
+      if (! in_array($isoCode, $availableIsoCodes)) {
         return false;
       }
 


### PR DESCRIPTION
As far as I know, parcel terminals available only in Lithuania, I could not find the solution to hide this carrier for other countries, so maybe this is the solution.

If you think this is the approach, you are welcome 😁
